### PR TITLE
Use Next.js Link for navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Gamemaster MVP',
@@ -13,6 +14,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="container">
           <header className="mb-6 py-4 border-b border-gray-200 dark:border-gray-800">
             <h1 className="text-2xl font-semibold">Gamemaster MVP</h1>
+            <nav className="mt-2 flex gap-4 text-blue-600">
+              <Link href="/">Home</Link>
+              <Link href="/table">Table</Link>
+              <Link href="/mobile">Mobile</Link>
+            </nav>
           </header>
           {children}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export default function Home() {
   return (
     <main className="space-y-4">
@@ -5,8 +7,18 @@ export default function Home() {
         Choose a surface to get started.
       </p>
       <div className="flex gap-4">
-        <a href="/table" className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-500">Table</a>
-        <a href="/mobile" className="px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-500">Mobile</a>
+        <Link
+          href="/table"
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-500"
+        >
+          Table
+        </Link>
+        <Link
+          href="/mobile"
+          className="px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-500"
+        >
+          Mobile
+        </Link>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- switch home page buttons for Table and Mobile to Next.js `Link`
- add header navigation with links to home, table, and mobile across the site

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68993f05d8888321aeb66c11f8b468d8