### PR TITLE
Improve table and mobile UX with instructions overlay

### DIFF
--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -81,7 +81,7 @@ export default function MobilePage() {
       if (saved && saved.playerId && saved.roomCode) {
         setPlayerId(saved.playerId);
         setRoomCode(saved.roomCode);
-        if (saved.name) setName(saved.name);
+        if (saved.name) setName(saved.name.slice(0,16));
         if (saved.joined) setJoined(true);
         if (saved.avatar) setAvatar(saved.avatar);
       }
@@ -118,7 +118,7 @@ export default function MobilePage() {
       try {
         const saved = JSON.parse(localStorage.getItem("gm.session") || "null");
         if (saved && saved.joined && saved.roomCode && saved.playerId && saved.name) {
-          s.emit("joinRoom", { roomCode: saved.roomCode, playerId: saved.playerId, name: saved.name, avatar: saved.avatar });
+          s.emit("joinRoom", { roomCode: saved.roomCode, playerId: saved.playerId, name: saved.name.slice(0,16), avatar: saved.avatar });
           s.emit("getHand", { roomCode: saved.roomCode, playerId: saved.playerId });
         }
       } catch {}
@@ -160,7 +160,7 @@ export default function MobilePage() {
   const join = () => {
     if (!socket || !roomCode || !name) return;
     const normalized = roomCode.trim().toUpperCase();
-    const trimmedName = name.trim();
+    const trimmedName = name.trim().slice(0,16);
     setRoomCode(normalized); // ensure subsequent emits match server room key
     socket.emit("joinRoom", { roomCode: normalized, playerId, name: trimmedName, avatar });
     setJoined(true);
@@ -168,7 +168,7 @@ export default function MobilePage() {
     try {
       localStorage.setItem(
         "gm.session",
-        JSON.stringify({ roomCode: normalized, playerId, name: trimmedName, avatar, joined: true })
+    JSON.stringify({ roomCode: normalized, playerId, name: trimmedName, avatar, joined: true })
       );
     } catch {}
   };
@@ -208,7 +208,7 @@ export default function MobilePage() {
   };
 
   return (
-    <main className={`space-y-4 transition-colors ${myTurn ? 'bg-emerald-50 dark:bg-emerald-900/20 -mx-4 px-4 py-2 rounded' : ''}`}>
+    <main className={`space-y-4 transition-colors ${myTurn ? 'bg-emerald-200 dark:bg-emerald-800/50 ring-4 ring-emerald-500 -mx-4 px-4 py-2 rounded' : ''}`}>
       <h2 className="text-xl font-semibold">Mobile</h2>
       {room?.winner && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
@@ -278,7 +278,8 @@ export default function MobilePage() {
             className="block mt-1 border rounded px-3 py-2 w-full bg-white/80 dark:bg-black/20"
             placeholder="e.g. Alex"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            maxLength={16}
+            onChange={(e) => setName(e.target.value.slice(0,16))}
           />
         </label>
         <div>
@@ -288,7 +289,7 @@ export default function MobilePage() {
               <button
                 key={a}
                 type="button"
-                className={`h-10 w-10 rounded-full flex items-center justify-center text-xl shadow border ${avatar === a ? 'ring-2 ring-emerald-500 bg-emerald-50 dark:bg-emerald-900/30' : 'bg-white/80 dark:bg-black/20'}`}
+                className={`h-12 w-12 rounded-full flex items-center justify-center text-2xl shadow border ${avatar === a ? 'ring-2 ring-emerald-500 bg-emerald-50 dark:bg-emerald-900/30' : 'bg-white/80 dark:bg-black/20'}`}
                 onClick={() => setAvatar(a)}
                 aria-label={`Select avatar ${a}`}
               >

--- a/public/UNO.md
+++ b/public/UNO.md
@@ -1,0 +1,103 @@
+# UNO – Classic Rules (Markdown Edition)
+
+## Overview
+UNO is a shedding-type card game for 2–10 players. First player to 500 points (or a house-ruled target) wins.  
+Players race to get rid of all their cards by matching the top card of the discard pile by **color** or **number/symbol**. Strategic play (and shameless spite) encouraged.
+
+---
+
+## Components
+- **108 cards total**:
+  - **Number cards** (0–9 in four colors: Red, Yellow, Green, Blue)
+  - **Action cards** (per color):
+    - Skip (2 per color)
+    - Reverse (2 per color)
+    - Draw Two (+2) (2 per color)
+  - **Wild cards**:
+    - Wild (4)
+    - Wild Draw Four (+4) (4)
+
+---
+
+## Setup
+1. Shuffle the deck thoroughly.
+2. Each player draws one card; highest number deals.
+3. Dealer gives **7 cards** to each player.
+4. Place the remaining deck face-down as the draw pile.
+5. Flip the top card to start the discard pile:
+   - If it’s an **Action card**, apply it as if it were played by the dealer (Wilds let dealer choose color).
+
+---
+
+## Game Play
+Players take turns clockwise (unless reversed).
+
+### On Your Turn:
+You must play **one card** from your hand that matches the top discard by:
+- **Color** (e.g., blue card on blue card)
+- **Number** (e.g., any “5” on any “5”)
+- **Symbol** (e.g., Skip on Skip)
+- **Wild** (change color anytime)
+
+If you can’t play:
+- Draw 1 card from the draw pile.
+- If you can play it immediately, you may.
+- Otherwise, your turn ends.
+
+---
+
+## Action Cards
+- **Skip** – Next player loses their turn.
+- **Reverse** – Changes direction of play.
+- **Draw Two (+2)** – Next player draws 2 cards and loses turn.
+- **Wild** – Player chooses the next color.
+- **Wild Draw Four (+4)** – Player chooses the next color, and next player draws 4 cards and loses turn.
+  - Can only be played if you have **no cards** matching the current color (numbers don’t matter).  
+    If challenged and you were bluffing, you must draw 4 instead.
+
+---
+
+## Special Rules
+- **UNO Call** – When you have one card left, you must yell “UNO!” before the next player starts their turn.
+  - Fail, and you must draw 2 penalty cards if caught.
+- **Draw Pile Exhaustion** – If the draw pile runs out, shuffle the discard pile (leave top card) to form a new draw pile.
+- **No Card to Play** – If you can’t play even after drawing, pass your turn.
+
+---
+
+## Scoring
+At the end of a round, winner scores points for opponents’ remaining cards:
+- Number cards: face value
+- Draw Two, Skip, Reverse: 20 points each
+- Wild, Wild Draw Four: 50 points each
+
+---
+
+## Winning
+- **Standard**: First to 500 points wins.
+- **Short Game**: First to 200 points wins.
+- **One Round**: Play until one player wins a single hand.
+
+---
+
+## Quick Reference Table
+
+| Card Type         | Effect                                                      | Points |
+|------------------|--------------------------------------------------------------|--------|
+| Number (0–9)      | Match color or number                                        | Value  |
+| Skip              | Next player misses turn                                      | 20     |
+| Reverse           | Reverse play direction                                       | 20     |
+| Draw Two (+2)     | Next player draws 2 and misses turn                          | 20     |
+| Wild              | Choose the next color                                        | 50     |
+| Wild Draw Four (+4)| Choose color, next draws 4 (only if no matching color)       | 50     |
+
+---
+
+## House Rules Variants (Optional)
+- **Stacking** – Allow stacking Draw Twos and Wild Draw Fours on matching cards to pass the pain along.
+- **Progressive UNO** – Draw Two on Draw Two forces next player to draw 4, etc.
+- **Seven-Zero Rule** – Play a “7” to swap hands with any player; play a “0” to rotate hands in play direction.
+
+---
+
+Yes, it’s just a card game, but in practice it’s a highly-engineered friendship stress test.


### PR DESCRIPTION
## Summary
- slow card play animation before moving to discard
- add instructions overlay with UNO rules and larger avatars around the table
- emphasize mobile turn state and cap player names at 16 characters

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689944a72cb08321987a42d8faa1fbee