### PR TITLE
feat: Improve deck visuals and remove card borders

### DIFF
--- a/app/table/page.tsx
+++ b/app/table/page.tsx
@@ -27,7 +27,7 @@ function UnoCard({ code }: { code: string }) {
     return { src, label };
   }, [code]);
   return (
-    <div className="relative w-32 h-48 rounded shadow border overflow-hidden">
+    <div className="relative w-32 h-48 rounded shadow-lg overflow-hidden">
       <Image src={src} alt={code} fill style={{ objectFit: 'cover' }} />
       <div className="absolute inset-0 flex items-center justify-center text-white font-bold text-base drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)]">
         {label}
@@ -49,6 +49,8 @@ type RoomState = {
   code: string;
   status: "lobby" | "active" | "finished";
   discardTop: string | null;
+  deckCount: number;
+  discardCount: number;
   playerCounts: { id: string; name: string; avatar?: string | null; count: number }[];
   turn: string | null;
   winner: string | null;
@@ -390,15 +392,39 @@ export default function TablePage() {
                 )}
               </div>
             )}
-            <div className="text-sm flex items-center gap-2">Discard Top: <span className="font-mono">{room.discardTop ?? "—"}</span>
-              {room.discardTop && (
-                <div ref={discardRef} className="ml-2 flex flex-col items-center" aria-label={`Discard ${room.discardTop}`}>
-                  <UnoCard code={room.discardTop} />
-                  <div className="mt-1 text-[10px] leading-none font-mono text-gray-700 dark:text-gray-300" aria-hidden>
-                    {room.discardTop}
-                  </div>
+            <div className="text-sm flex items-end gap-4">
+              <div>
+                <span className="font-mono text-xs">Draw Deck</span>
+                <div className="relative w-32 h-48">
+                  {Array.from({ length: Math.min(5, room.deckCount) }).map((_, i) => (
+                    <div key={i} className="absolute w-full h-full rounded shadow-lg overflow-hidden" style={{ transform: `translate(${i*2}px, ${i*1}px)` }}>
+                      <Image src="/uno/uno_back.png" alt="Card Back" fill style={{ objectFit: 'cover' }} />
+                    </div>
+                  ))}
                 </div>
-              )}
+                <div className="mt-1 text-center text-[10px] leading-none font-mono text-gray-700 dark:text-gray-300">
+                  {room.deckCount} cards
+                </div>
+              </div>
+              <div>
+                <span className="font-mono text-xs">Discard Pile</span>
+                {room.discardTop ? (
+                  <div ref={discardRef} className="relative w-32 h-48" aria-label={`Discard ${room.discardTop}`}>
+                    {Array.from({ length: Math.min(5, room.discardCount) }).map((_, i) => (
+                      <div key={i} className="absolute w-full h-full" style={{ transform: `translate(${i*2}px, ${i*1}px)` }}>
+                        <UnoCard code={room.discardTop} />
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="relative w-32 h-48 border-2 border-dashed rounded border-white/20 flex items-center justify-center">
+                    <span className="text-xs text-white/40">Empty</span>
+                  </div>
+                )}
+                <div className="mt-1 text-center text-[10px] leading-none font-mono text-gray-700 dark:text-gray-300" aria-hidden>
+                  {room.discardCount} cards
+                </div>
+              </div>
             </div>
             <div className="text-sm">Turn: <span className="font-mono">{room.turn ?? "—"}</span>{currentPlayerName ? ` – ${currentPlayerName}` : ''}</div>
             {room.status === 'finished' && (

--- a/server.js
+++ b/server.js
@@ -443,6 +443,8 @@ function serializeRoom(room) {
     gameId: room.gameId,
     status: room.status,
     discardTop: room.discard[0] || null,
+    deckCount: room.deck?.length || 0,
+    discardCount: room.discard?.length || 0,
     playerCounts: Array.from(room.players.entries()).map(([id, p]) => ({ id, name: p.name, avatar: p.avatar || null, count: p.hand.length })),
     turn: room.order[room.turnIndex] || null,
     winner: room.winner || null,


### PR DESCRIPTION
- Removes the border from Uno cards for a cleaner look with transparent backgrounds.
- Adds a draw deck next to the discard pile.
- Implements a stacking effect for both the draw and discard decks to visually represent the number of cards in each pile.