### PR TITLE
Fix toast notification duplication and mobile layout tweaks

### DIFF
--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -247,7 +247,8 @@ export default function MobilePage() {
   };
 
   return (
-    <main className={`space-y-4 transition-colors ${myTurn ? 'bg-emerald-300 dark:bg-emerald-700 ring-8 ring-emerald-500 -mx-4 px-4 py-2 rounded shadow-xl' : ''}`}>
+    <>
+    <main className={`space-y-4 transition-colors pb-16 ${myTurn ? 'bg-emerald-300 dark:bg-emerald-700 ring-8 ring-emerald-500 -mx-4 px-4 py-2 rounded shadow-xl' : ''}`}>
       {joined && (
         <button
           className={`fixed top-2 right-2 z-50 p-2 rounded-full bg-white/80 dark:bg-black/40 ${showPlayable ? 'text-emerald-600' : ''}`}
@@ -309,7 +310,7 @@ export default function MobilePage() {
       )}
 
     {!joined ? (
-      <div className="space-y-3">
+      <div className="space-y-3 pb-12">
         <div className="text-xs text-gray-500">Your ID: <span className="font-mono">{playerId}</span></div>
         <label className="block">
           <span className="text-sm">Room Code</span>
@@ -363,10 +364,7 @@ export default function MobilePage() {
         </div>
       </div>
     ) : (
-      <div className="space-y-3">
-        <div className="text-sm">Room: <span className="font-mono">{room?.code ?? roomCode}</span></div>
-        <div className="text-sm">Game: {room?.gameId ?? "—"}</div>
-        <div className="text-sm">Status: {room?.status ?? "—"}</div>
+      <div className="space-y-3 pb-12">
         <div className="text-sm flex items-center gap-2">Discard Top: <span className="font-mono">{room?.discardTop ?? "—"}</span>
           {room?.discardTop && (
             <div className="ml-2 flex flex-col items-center" aria-label={`Discard ${room.discardTop}`}>
@@ -377,7 +375,6 @@ export default function MobilePage() {
             </div>
           )}
           </div>
-          <div className="text-sm">My Turn: {myTurn ? "Yes" : "No"}</div>
           {room?.log && room.log.length > 0 && (
             <div className="mt-2">
               <h3 className="font-medium mb-1">Log</h3>
@@ -451,13 +448,8 @@ export default function MobilePage() {
               <div className="flex gap-2">
                 <button
                   className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
-                  disabled={!socket || !roomCode}
-                  onClick={() => {
-                    if (!myTurn) {
-                      notify("error", "Not your turn");
-                    }
-                    draw();
-                  }}
+                  disabled={!socket || !roomCode || !myTurn}
+                  onClick={() => draw()}
                 >
                   Draw
                 </button>
@@ -469,5 +461,12 @@ export default function MobilePage() {
         </div>
       )}
     </main>
+    <div className="fixed bottom-0 left-0 right-0 text-[10px] sm:text-xs flex justify-around gap-2 p-1 bg-white/70 dark:bg-black/70">
+      <span>Room: <span className="font-mono">{room?.code ?? roomCode || '—'}</span></span>
+      <span>Game: {room?.gameId ?? '—'}</span>
+      <span>Status: {room?.status ?? '—'}</span>
+      <span>My Turn: {myTurn ? 'Yes' : 'No'}</span>
+    </div>
+    </>
   );
 }

--- a/app/table/page.tsx
+++ b/app/table/page.tsx
@@ -168,7 +168,6 @@ export default function TablePage() {
     });
     s.on("cardPlayed", ({ playerId, name, card }: { playerId: string; name: string; card: string }) => {
       if (!card) return;
-      notify("draw", `${name.slice(0,16)} played a ${readableCard(card)}`);
       setPlayed({ playerId, name: name.slice(0,16), card });
       setPlayedStyle({ opacity: 0 });
       pendingPlayerRef.current = playerId;

--- a/components/Notifications.tsx
+++ b/components/Notifications.tsx
@@ -64,23 +64,27 @@ export function Notifications({ children }: { children: ReactNode }) {
 
   const notify = (type: "error" | "notice" | "draw", message: string) => {
     const DURATION = 5000;
-    const canAggregate = type === 'draw' && message.endsWith('drew a card');
+    const normalized = message.trim();
+    const base = normalized.replace(/[.!]$/, "");
+    const canAggregate = type === 'draw' && /drew a card$/i.test(base);
 
-    if (activeAggregate && (!canAggregate || activeAggregate.baseMessage !== message)) {
+    if (activeAggregate && (!canAggregate || activeAggregate.baseMessage !== base)) {
       setActiveAggregate(null);
     }
 
-    if (canAggregate && activeAggregate?.baseMessage === message) {
+    if (canAggregate && activeAggregate?.baseMessage === base) {
       const newCount = activeAggregate.count + 1;
-      const newToastMessage = `${message} (x${newCount})`;
-      setToasts(prev => prev.map(t => t.id === activeAggregate.id ? { ...t, message: newToastMessage } : t));
+      const newToastMessage = `${base} (x${newCount})`;
+      setToasts(prev =>
+        prev.map(t => (t.id === activeAggregate.id ? { ...t, message: newToastMessage } : t))
+      );
       setActiveAggregate(prev => ({ ...prev!, count: newCount }));
       resetToastTimer(activeAggregate.id, DURATION);
     } else {
       const id = Date.now();
-      addToast({ id, type, message }, DURATION);
+      addToast({ id, type, message: canAggregate ? base : normalized }, DURATION);
       if (canAggregate) {
-        setActiveAggregate({ id, baseMessage: message, count: 1 });
+        setActiveAggregate({ id, baseMessage: base, count: 1 });
       }
     }
   };


### PR DESCRIPTION
## Summary
- prevent duplicate toasts when cards are played
- aggregate draw toasts using counter
- adjust mobile layout: bottom status bar and disabled draw button when not your turn

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689a5db011a083219e20559fef2d3b85