### PR TITLE
Add Flip7 bust overlay and round ready flow

### DIFF
--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -83,7 +83,7 @@ function isLegalPlay(card: string, top: string | null) {
 type RoomState = {
   code: string;
   gameId?: string;
-  status: "lobby" | "active" | "finished";
+  status: "lobby" | "active" | "finished" | "between";
   discardTop: string | null;
   playerCounts: { id: string; name: string; avatar?: string | null; count: number }[];
   turn: string | null;
@@ -97,6 +97,8 @@ type RoomState = {
     uniquesCount: { id: string; name: string; count: number }[];
     roundOver: boolean;
     hands?: { id: string; name: string; cards: string[] }[];
+    pendingFlip3?: string | null;
+    ready?: string[];
   };
 };
 
@@ -211,7 +213,7 @@ export default function MobilePage() {
 
   const myTurn = useMemo(() => {
     if (!room) return false;
-    return room.turn === playerId;
+    return room.status === 'active' && room.turn === playerId;
   }, [room, playerId]);
   const winnerName = useMemo(() => {
     if (!room?.winner) return null;
@@ -239,6 +241,8 @@ export default function MobilePage() {
   const pass = () => socket?.emit("passTurn", { roomCode, playerId });
   const flip7Hit = () => socket?.emit("flip7:hit", { roomCode, playerId });
   const flip7Stay = () => socket?.emit("flip7:stay", { roomCode, playerId });
+  const flip3Target = (targetId: string) => socket?.emit("flip7:flip3Target", { roomCode, playerId, targetId });
+  const startNextRound = () => socket?.emit("flip7:startNextRound", { roomCode, playerId });
   const play = (idx: number) => {
     if (!socket) return;
     const card = hand[idx];
@@ -413,10 +417,17 @@ export default function MobilePage() {
             <>
               <div>
                 <h3 className="font-medium mb-1">My Cards</h3>
-                <div className="flex flex-wrap gap-3">
-                  {hand.map((c, idx) => (
-                    <Flip7Card key={`${c}-${idx}`} code={c} />
-                  ))}
+                <div className="relative">
+                  <div className="flex flex-wrap gap-3 opacity-100">
+                    {hand.map((c, idx) => (
+                      <Flip7Card key={`${c}-${idx}`} code={c} />
+                    ))}
+                  </div>
+                  {room.flip7?.busted.includes(playerId) && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-white/70">
+                      <span className="text-red-600 font-bold text-3xl">BUSTED</span>
+                    </div>
+                  )}
                 </div>
               </div>
               <div>
@@ -427,27 +438,53 @@ export default function MobilePage() {
                 <div className="mt-1 text-xs">Round Scores: {room.flip7?.roundScore.map(s => `${s.name}:${s.score}`).join(' | ') || '—'}</div>
                 <div className="mt-1 text-xs">Total Scores: {room.flip7?.scores.map(s => `${s.name}:${s.score}`).join(' | ') || '—'}</div>
               </div>
-              <div className="flex gap-2">
-                <button
-                  className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
-                  disabled={!socket || !roomCode || !myTurn}
-                  onClick={() => {
-                    if (!myTurn) { notify("error", 'Not your turn'); return; }
-                    flip7Hit();
-                  }}
-                >
-                  Hit
-                </button>
-                <button
-                  className="px-4 py-2 rounded bg-slate-600 text-white disabled:opacity-50"
-                  disabled={!myTurn}
-                  onClick={() => flip7Stay()}
-                >
-                  Stay
-                </button>
-                <button className="px-4 py-2 rounded bg-amber-600 text-white" onClick={changeRoom}>Change Room</button>
-                <button className="px-4 py-2 rounded bg-red-600 text-white" onClick={leave}>Leave Room</button>
-              </div>
+              {room.flip7?.pendingFlip3 === playerId && (
+                <div className="mt-2">
+                  <h3 className="font-medium mb-1">Choose player for Flip3</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {room.flip7?.hands?.map(p => (
+                      <button key={p.id} className="px-2 py-1 rounded bg-amber-600 text-white" onClick={() => flip3Target(p.id)}>
+                        {p.name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {room.status === 'between' ? (
+                <div className="flex gap-2">
+                  {room.flip7?.ready?.includes(playerId) ? (
+                    <span className="px-4 py-2">Waiting for others...</span>
+                  ) : (
+                    <button className="px-4 py-2 rounded bg-green-600 text-white" onClick={startNextRound}>
+                      Start Next Round
+                    </button>
+                  )}
+                  <button className="px-4 py-2 rounded bg-amber-600 text-white" onClick={changeRoom}>Change Room</button>
+                  <button className="px-4 py-2 rounded bg-red-600 text-white" onClick={leave}>Leave Room</button>
+                </div>
+              ) : (
+                <div className="flex gap-2">
+                  <button
+                    className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+                    disabled={!socket || !roomCode || !myTurn}
+                    onClick={() => {
+                      if (!myTurn) { notify("error", 'Not your turn'); return; }
+                      flip7Hit();
+                    }}
+                  >
+                    Hit
+                  </button>
+                  <button
+                    className="px-4 py-2 rounded bg-slate-600 text-white disabled:opacity-50"
+                    disabled={!myTurn}
+                    onClick={() => flip7Stay()}
+                  >
+                    Stay
+                  </button>
+                  <button className="px-4 py-2 rounded bg-amber-600 text-white" onClick={changeRoom}>Change Room</button>
+                  <button className="px-4 py-2 rounded bg-red-600 text-white" onClick={leave}>Leave Room</button>
+                </div>
+              )}
             </>
           ) : (
             <>

--- a/app/table/page.tsx
+++ b/app/table/page.tsx
@@ -70,14 +70,21 @@ function readableCard(code: string) {
 type RoomState = {
   code: string;
   gameId?: string;
-  status: "lobby" | "active" | "finished";
+  status: "lobby" | "active" | "finished" | "between";
   discardTop: string | null;
   deckCount: number;
   discardCount: number;
   playerCounts: { id: string; name: string; avatar?: string | null; count: number }[];
   turn: string | null;
   winner: string | null;
-  flip7?: { hands: { id: string; name: string; cards: string[] }[]; stayed: string[]; busted: string[] };
+  flip7?: {
+    hands: { id: string; name: string; cards: string[] }[];
+    stayed: string[];
+    busted: string[];
+    roundOver?: boolean;
+    pendingFlip3?: string | null;
+    ready?: string[];
+  };
 };
 
 type GameInfo = { id: string; name: string };
@@ -428,23 +435,30 @@ export default function TablePage() {
                 )}
               </div>
             )}
-            <div className="text-sm flex items-end gap-4">
+            <div className="text-sm">
               {room.gameId === 'flip7' ? (
-                <div>
-                  <span className="font-mono text-xs">Draw Deck</span>
-                  <div className="relative w-32 h-48">
-                    {Array.from({ length: Math.min(5, room.deckCount) }).map((_, i) => (
-                      <div key={i} className="absolute w-full h-full rounded overflow-hidden" style={{ transform: `translate(${i*2}px, ${i*1}px)` }}>
-                        <Image src="/flip7/F7_Back.png" alt="Card Back" fill style={{ objectFit: 'cover' }} />
+                <div className="flex flex-col gap-2">
+                  {room.flip7?.hands.map(p => (
+                    <div key={p.id} className="flex items-center gap-2">
+                      <div className="font-semibold">
+                        {p.name}
+                        {room.flip7?.stayed.includes(p.id) ? ' (Stayed)' : ''}
                       </div>
-                    ))}
-                  </div>
-                  <div className="mt-1 text-center text-[10px] leading-none font-mono text-gray-700 dark:text-gray-300">
-                    {room.deckCount} cards
-                  </div>
+                      <div className="relative flex gap-1">
+                        {room.flip7?.busted.includes(p.id) && (
+                          <div className="absolute inset-0 flex items-center justify-center bg-white/70">
+                            <span className="text-red-600 font-bold">BUSTED</span>
+                          </div>
+                        )}
+                        {p.cards.map((c, i) => (
+                          <Flip7Card key={i} code={c} />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               ) : (
-                <>
+                <div className="flex items-end gap-4">
                   <div>
                     <span className="font-mono text-xs">Draw Deck</span>
                     <div className="relative w-32 h-48">
@@ -461,7 +475,7 @@ export default function TablePage() {
                   <div>
                     <span className="font-mono text-xs">Discard Pile</span>
                     {room.discardTop ? (
-                      <div ref={discardRef} className="relative w-32 h-48" aria-label={`Discard ${room.discardTop}`}>
+                      <div ref={discardRef} className="relative w-32 h-48" aria-label={`Discard ${room.discardTop}`}> 
                         {Array.from({ length: Math.min(5, room.discardCount) }).map((_, i) => (
                           <div key={i} className="absolute w-full h-full" style={{ transform: `translate(${i*2}px, ${i*1}px)` }}>
                             <UnoCard code={room.discardTop!} />
@@ -477,7 +491,7 @@ export default function TablePage() {
                       {room.discardCount} cards
                     </div>
                   </div>
-                </>
+                </div>
               )}
             </div>
             <div className="text-sm">Turn: <span className="font-mono">{room.turn ?? "—"}</span>{currentPlayerName ? ` – ${currentPlayerName}` : ''}</div>
@@ -491,29 +505,9 @@ export default function TablePage() {
                 })()}
               </div>
             )}
-            <div>
-              <h4 className="font-medium">Players</h4>
-              {room.gameId === 'flip7' ? (
-                <div className="flex flex-wrap gap-4 mt-2">
-                  {room.flip7?.hands.map(p => (
-                    <div key={p.id}>
-                      <div className="font-semibold">
-                        {p.name}
-                        {room.flip7?.stayed.includes(p.id)
-                          ? ' (Stayed)'
-                          : room.flip7?.busted.includes(p.id)
-                          ? ' (Busted)'
-                          : ''}
-                      </div>
-                      <div className="flex gap-1 mt-1">
-                        {p.cards.map((c, i) => (
-                          <Flip7Card key={i} code={c} />
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
+            {room.gameId !== 'flip7' && (
+              <div>
+                <h4 className="font-medium">Players</h4>
                 <table className="w-full text-sm mt-2">
                   <thead>
                     <tr className="text-left">
@@ -532,8 +526,8 @@ export default function TablePage() {
                     ))}
                   </tbody>
                 </table>
-              )}
-            </div>
+              </div>
+            )}
           </div>
         )}
       </section>

--- a/public/FLIP7.md
+++ b/public/FLIP7.md
@@ -45,6 +45,7 @@
 
 * You bust if you draw a Number card with a value you already have.
 * Action and Modifier cards do not cause busts.
+* If you bust, you score 0 points for that round.
 
 ---
 
@@ -75,6 +76,8 @@ The round ends when:
 
 1. All players have stayed or busted.
 2. A player flips 7 unique Number cards.
+
+After scoring, the next round begins once all players press **Start Next Round** on their devices.
 
 ---
 


### PR DESCRIPTION
## Goal
- Show clear BUSTED state for Flip7 players
- Let Flip Three cards target any player
- Require all players to confirm before starting next Flip7 round
- Ensure Next.js build succeeds

## Approach
- Overlay red **BUSTED** tag on busted players' cards in table and mobile views
- Track pending Flip Three selections and emit socket events to choose recipients
- Pause between rounds until each player presses **Start Next Round**
- Guard access to Flip7 hand and ready arrays to avoid undefined errors during build

## Alternatives
- Automatically assign Flip Three cards to the drawing player
- Auto-start new rounds immediately after scoring

## Risks
- Added Flip7 state may introduce edge cases in turn flow
- More UI states could confuse players if not fully tested

## Testing
- `npm test`
- `npm run lint` (prompts for configuration)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a88afd37883219ccd41f1ce3bc7ea