### PR TITLE
feat: add flip7 freeze targeting and second chance rules

### DIFF
--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -98,6 +98,10 @@ type RoomState = {
     roundOver: boolean;
     hands?: { id: string; name: string; cards: string[] }[];
     pendingFlip3?: string | null;
+    pendingFreeze?: string | null;
+    pendingSecondChance?: string | null;
+    pendingSecondChanceGift?: string | null;
+    secondChance?: string[];
     ready?: string[];
   };
 };
@@ -242,6 +246,9 @@ export default function MobilePage() {
   const flip7Hit = () => socket?.emit("flip7:hit", { roomCode, playerId });
   const flip7Stay = () => socket?.emit("flip7:stay", { roomCode, playerId });
   const flip3Target = (targetId: string) => socket?.emit("flip7:flip3Target", { roomCode, playerId, targetId });
+  const freezeTarget = (targetId: string) => socket?.emit("flip7:freezeTarget", { roomCode, playerId, targetId });
+  const useSecondChance = () => socket?.emit("flip7:useSecondChance", { roomCode, playerId });
+  const giftSecondChance = (targetId: string) => socket?.emit("flip7:giftSecondChance", { roomCode, playerId, targetId });
   const startNextRound = () => socket?.emit("flip7:startNextRound", { roomCode, playerId });
   const play = (idx: number) => {
     if (!socket) return;
@@ -447,6 +454,39 @@ export default function MobilePage() {
                         {p.name}
                       </button>
                     ))}
+                  </div>
+                </div>
+              )}
+              {room.flip7?.pendingFreeze === playerId && (
+                <div className="mt-2">
+                  <h3 className="font-medium mb-1">Choose player to Freeze</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {room.flip7?.hands?.map(p => (
+                      <button key={p.id} className="px-2 py-1 rounded bg-amber-600 text-white" onClick={() => freezeTarget(p.id)}>
+                        {p.name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {room.flip7?.pendingSecondChance === playerId && (
+                <div className="mt-2">
+                  <button className="px-4 py-2 rounded bg-green-600 text-white" onClick={useSecondChance}>
+                    Use Your Second Chance
+                  </button>
+                </div>
+              )}
+              {room.flip7?.pendingSecondChanceGift === playerId && (
+                <div className="mt-2">
+                  <h3 className="font-medium mb-1">Give Second Chance to</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {room.flip7?.hands
+                      ?.filter(p => p.id !== playerId && !(room.flip7?.secondChance || []).includes(p.id))
+                      .map(p => (
+                        <button key={p.id} className="px-2 py-1 rounded bg-amber-600 text-white" onClick={() => giftSecondChance(p.id)}>
+                          {p.name}
+                        </button>
+                      ))}
                   </div>
                 </div>
               )}

--- a/app/table/page.tsx
+++ b/app/table/page.tsx
@@ -83,6 +83,10 @@ type RoomState = {
     busted: string[];
     roundOver?: boolean;
     pendingFlip3?: string | null;
+    pendingFreeze?: string | null;
+    pendingSecondChance?: string | null;
+    pendingSecondChanceGift?: string | null;
+    secondChance?: string[];
     ready?: string[];
   };
 };

--- a/docs/FLIP7.md
+++ b/docs/FLIP7.md
@@ -32,9 +32,9 @@ Flip 7 is a cheeky push-your-luck card game for 3+ players, ages 8+. First to 20
 ---
 
 ## Action Cards Explained  
-- **Freeze**: Targeted player banks their current points and is out for the round. :contentReference[oaicite:10]{index=10}  
-- **Flip Three**: Target must draw three cards in sequence. Duplicates still bust you. If another action appears while drawing, it resolves *after* the three draws—or after a bust. :contentReference[oaicite:11]{index=11}  
-- **Second Chance**: Stash it. If you bust with a duplicate, discard the duplicate *and* this card instead of busting. Only one can be held—extra ones must be passed on or discarded. Discard all at round end. :contentReference[oaicite:12]{index=12}
+- **Freeze**: When drawn, choose any player (including yourself) to immediately bank their current points and sit out the round. :contentReference[oaicite:10]{index=10}
+- **Flip Three**: Target must draw three cards in sequence. Duplicates still bust you. If another action appears while drawing, it resolves *after* the three draws—or after a bust. :contentReference[oaicite:11]{index=11}
+- **Second Chance**: Stash it. If you would bust with a duplicate, press **Use Your Second Chance** to discard the duplicate *and* this card instead. Only one may be held—extra copies must be given to a player without one or discarded if none exist. Discard all at round end. :contentReference[oaicite:12]{index=12}
 
 > If you're the only active player left, you get to play any Action cards on yourself. Because why not? :contentReference[oaicite:13]{index=13}
 

--- a/public/FLIP7.md
+++ b/public/FLIP7.md
@@ -51,9 +51,9 @@
 
 ## Action Cards
 
-* **Freeze!** — Target player banks points and is out of the round.
+* **Freeze!** — When drawn, choose any player (including yourself) to bank points and sit out the round.
 * **Flip Three!** — Target player draws three cards in a row, resolving them in order. Bust or Flip 7 ends this sequence early.
-* **Second Chance** — Keeps you from busting once by discarding both the duplicate Number card and this card. Only one allowed per player.
+* **Second Chance** — Keeps you from busting once by discarding both the duplicate Number card and this card when you press **Use Your Second Chance**. Only one allowed per player; extra copies must be given to someone without one or discarded if none.
 
 ---
 


### PR DESCRIPTION
## Goal
- let Flip7 players choose any target for Freeze cards
- enforce one Second Chance per player with confirmation and gifting

## Approach
- track pending Freeze/Second Chance actions on the server and handle new socket events
- update mobile UI for Freeze targeting, Second Chance confirmation, and gifting
- document updated Freeze and Second Chance rules

## Alternatives
- auto-freeze the drawing player or auto-use Second Chance without confirmation

## Risks
- additional game states could introduce edge cases if actions resolve out of order

## Testing
- `npm test`
- `npm run lint` *(prompts for ESLint setup; no config present)*

------
https://chatgpt.com/codex/tasks/task_e_689a924169f883218f8a8d59ae31f981