### PR TITLE
Show bust/frozen overlays on table view hands

### DIFF
--- a/app/table/page.tsx
+++ b/app/table/page.tsx
@@ -450,19 +450,19 @@ export default function TablePage() {
                         {room.flip7?.stayed.includes(p.id) ? ' (Stayed)' : ''}
                       </div>
                       <div className="relative flex gap-1">
+                        {p.cards.map((c, i) => (
+                          <Flip7Card key={i} code={c} />
+                        ))}
                         {room.flip7?.busted.includes(p.id) && (
-                          <div className="absolute inset-0 flex items-center justify-center bg-white/70">
+                          <div className="absolute inset-0 flex items-center justify-center bg-white/70 z-10">
                             <span className="text-red-600 font-bold">BUSTED</span>
                           </div>
                         )}
                         {(room.flip7?.frozen || []).includes(p.id) && (
-                          <div className="absolute inset-0 flex items-center justify-center bg-white/70">
+                          <div className="absolute inset-0 flex items-center justify-center bg-white/70 z-10">
                             <span className="text-blue-600 font-bold">FROZEN</span>
                           </div>
                         )}
-                        {p.cards.map((c, i) => (
-                          <Flip7Card key={i} code={c} />
-                        ))}
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
## Goal
Display status overlays for frozen or busted players on the table view hands.

## Approach
- Move overlay elements after card list in `app/table/page.tsx` and add `z-10` to ensure they render above cards.

## Alternatives
- Could have kept order and used higher z-index; changing order keeps markup similar to mobile view.

## Risks
- None expected; overlays only appear when status arrays contain player IDs.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a98e98998832193383dc1a5c23c89